### PR TITLE
chore: split CI qa step, add manual release job

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -1,0 +1,28 @@
+name: Manual release
+
+on:
+  workflow_dispatch
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+      - name: Install dependencies
+        run: npm ci
+      - name: Build lib
+        run: npm run build
+      - name: QA check
+        run: npm run qa
+      - name: Release
+        working-directory: lib
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx semantic-release

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,15 +1,13 @@
-name: Release CI
+name: QA
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
-  release:
+  qa:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,9 +23,3 @@ jobs:
         run: npm run build
       - name: QA check
         run: npm run qa
-      - name: Release
-        working-directory: lib
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release

--- a/lib/package.json
+++ b/lib/package.json
@@ -9,6 +9,14 @@
     "resolver",
     "renderer"
   ],
+  "homepage": "https://github.com/NordSecurity/storyblok-rich-text-astro-renderer",
+  "bugs": {
+    "url": "https://github.com/NordSecurity/storyblok-rich-text-astro-renderer/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/NordSecurity/storyblok-rich-text-astro-renderer"
+  },
   "license": "MIT",
   "author": "Edvinas Jurele",
   "exports": {
@@ -34,10 +42,18 @@
     "test:watch": "vitest watch",
     "ts:check": "tsc"
   },
+  "release": {
+    "branches": [
+      "main"
+    ]
+  },
   "devDependencies": {
     "@storyblok/js": "^2.1.3",
     "astro": "^2.3.0",
     "vite": "^4.3.1",
     "vite-plugin-dts": "^2.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Changes
 - split CI qa step to be automatic and run on each Pull Request
 - add manual release job
 - added missing release branch configuration for semantic-release