### PR TITLE
chore: set dependabot to run once weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "04:00"
     commit-message:
       prefix: fix


### PR DESCRIPTION
Running dependabot daily is not needed, weekly should be enough to start with.

Changes:
- Change dependabot frequency from `daily` to `weekly`