### PR TITLE
docs: update README with which nodes/marks are unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,22 +158,29 @@ schema={{
     paragraph: () => ({ ... }),
     text: () => ({ ... }),
     hard_break: () => ({ ... }),
-    horizontal_rule: () => ({ ... }),
-    bullet_list: () => ({ ... }),
-    blockquote: () => ({ ... }),
-    code_block: () => ({ ... }),
-    image: () => ({ ... }),
-    list_item: () => ({ ... }),
-    ordered_item: () => ({ ... }),
+    horizontal_rule: () => ({ ... }), // NOT SUPPORTED YET!
+    bullet_list: () => ({ ... }), // NOT SUPPORTED YET!
+    list_item: () => ({ ... }), // NOT SUPPORTED YET!
+    ordered_list: ({ attrs }) => ({ ... }), // NOT SUPPORTED YET!
+    ordered_item: () => ({ ... }), // NOT SUPPORTED YET!
+    blockquote: () => ({ ... }), // NOT SUPPORTED YET!
+    code_block: () => ({ ... }), // NOT SUPPORTED YET!
+    image: () => ({ ... }), // NOT SUPPORTED YET!
   },
   marks: {
     link: ({ attrs }) => { ... },
     bold: () => ({ ... }),
-    strong: () => ({ ... }),
     underline: () => ({ ... }),
     italic: () => ({ ... }),
-    strike: () => ({ ... }),
     styled: ({ attrs }) => { ... },
+    strike: () => ({ ... }), // NOT SUPPORTED YET!
+    superscript: () => ({ ... }), // NOT SUPPORTED YET!
+    subscript: () => ({ ... }), // NOT SUPPORTED YET!
+    code: () => ({ ... }), // NOT SUPPORTED YET!
+    anchor: ({ attrs }) => ({ ... }), // NOT SUPPORTED YET!
+    emoji: ({ attrs }) => ({ ... }), // NOT SUPPORTED YET!
+    textStyle: ({ attrs }) => ({ ... }), // NOT SUPPORTED YET!
+    highlight: ({ attrs }) => ({ ... }), // NOT SUPPORTED YET!
   };
 }}
 ```

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -17,22 +17,31 @@ export type Schema = {
     paragraph?: ResponseSchemaFn;
     text?: ResponseSchemaFn;
     hard_break?: ResponseSchemaFn;
-    horizontal_rule?: ResponseSchemaFn;
-    bullet_list?: ResponseSchemaFn;
-    blockquote?: ResponseSchemaFn;
-    code_block?: ResponseSchemaFn;
-    image?: ResponseSchemaFn;
-    list_item?: ResponseSchemaFn;
-    ordered_item?: ResponseSchemaFn;
+    // TODO: add support. The following are known, though not supported yet
+    // horizontal_rule?: ResponseSchemaFn;
+    // bullet_list?: ResponseSchemaFn;
+    // list_item?: ResponseSchemaFn;
+    // ordered_list?: ResponseSchemaAttrsFn;
+    // ordered_item?: ResponseSchemaFn;
+    // blockquote?: ResponseSchemaFn;
+    // code_block?: ResponseSchemaFn;
+    // image?: ResponseSchemaFn;
   };
   marks?: {
     link?: ResponseSchemaAttrsFn;
     bold?: ResponseSchemaFn;
-    strong?: ResponseSchemaFn;
     underline?: ResponseSchemaFn;
     italic?: ResponseSchemaFn;
-    strike?: ResponseSchemaFn;
     styled?: ResponseSchemaAttrsFn;
+    // TODO: add support. The following are known, though not supported yet
+    // strike?: ResponseSchemaFn;
+    // superscript?: ResponseSchemaFn;
+    // subscript?: ResponseSchemaFn;
+    // code?: ResponseSchemaFn;
+    // anchor?: ResponseSchemaAttrsFn;
+    // emoji?: ResponseSchemaAttrsFn;
+    // textStyle?: ResponseSchemaAttrsFn;
+    // highlight?: ResponseSchemaAttrsFn;
   };
 };
 


### PR DESCRIPTION
## Context

When releasing initial version of the package it was not clear which `nodes` and `marks` are supported. Moreover we have been added types to Schema as if they are supported, which was a wrong call.

The supported functionality is visible in https://github.com/NordSecurity/storyblok-rich-text-astro-renderer/blob/main/lib/src/utils/resolveRichTextToNodes.ts (or the tests file)

## Changes
 - Remove unsupported nodes/marks types from `Schema`
 - Update README to make it clear which `nodes` and `marks` are supported and which ones are still missing