### PR TITLE
Fix list_item node to not render fragment in HTML

### DIFF
--- a/lib/src/utils/resolveRichTextToNodes.spec.ts
+++ b/lib/src/utils/resolveRichTextToNodes.spec.ts
@@ -263,7 +263,6 @@ describe("resolveNode", () => {
       component: "li",
       content: [
         {
-          component: "Fragment",
           content: [
             {
               content: "one",
@@ -291,7 +290,6 @@ describe("resolveNode", () => {
       },
       content: [
         {
-          component: "Fragment",
           content: [{ content: "one" }],
         },
       ],
@@ -344,7 +342,6 @@ describe("resolveNode", () => {
           component: "li",
           content: [
             {
-              component: "Fragment",
               content: [{ content: "one" }],
             },
           ],
@@ -353,7 +350,6 @@ describe("resolveNode", () => {
           component: "li",
           content: [
             {
-              component: "Fragment",
               content: [{ content: "two" }],
             },
           ],
@@ -383,7 +379,6 @@ describe("resolveNode", () => {
           component: "li",
           content: [
             {
-              component: "Fragment",
               content: [{ content: "one" }],
             },
           ],
@@ -392,7 +387,6 @@ describe("resolveNode", () => {
           component: "li",
           content: [
             {
-              component: "Fragment",
               content: [{ content: "two" }],
             },
           ],
@@ -444,7 +438,6 @@ describe("resolveNode", () => {
           component: "li",
           content: [
             {
-              component: "Fragment",
               content: [{ content: "one" }],
             },
           ],
@@ -453,7 +446,6 @@ describe("resolveNode", () => {
           component: "li",
           content: [
             {
-              component: "Fragment",
               content: [{ content: "two" }],
             },
           ],
@@ -483,7 +475,6 @@ describe("resolveNode", () => {
           component: "li",
           content: [
             {
-              component: "Fragment",
               content: [{ content: "one" }],
             },
           ],
@@ -492,7 +483,6 @@ describe("resolveNode", () => {
           component: "li",
           content: [
             {
-              component: "Fragment",
               content: [{ content: "two" }],
             },
           ],

--- a/lib/src/utils/resolveRichTextToNodes.ts
+++ b/lib/src/utils/resolveRichTextToNodes.ts
@@ -134,7 +134,6 @@ export const resolveNode = (
         // skip rendering p tag inside li
         if (node.type === "paragraph") {
           return {
-            component: "Fragment",
             content: node.content.map((node) => resolveNode(node, options)),
           };
         }


### PR DESCRIPTION
## Context

When doing the support for list_item I accidently made the `<fragment>...</fragment>` in HTML. This should have skipped the HTML tag. This MR fixes this.

## Changes
 - Fix list_item node to not render fragment in HTML


## QA

Before: 

![image](https://github.com/NordSecurity/storyblok-rich-text-astro-renderer/assets/9308445/56bfc3fa-ecd5-420f-a7ba-b7140ad4b520)

After:

![image](https://github.com/NordSecurity/storyblok-rich-text-astro-renderer/assets/9308445/2e37030c-0f2d-4efb-ab6f-32e0b016f754)
