### PR TITLE
Handling edge cases on `heading` and `list_item` nodes

### DIFF
--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -124,7 +124,7 @@ export type Heading = {
   attrs: {
     level: 1 | 2 | 3 | 4 | 5 | 6;
   };
-  content: Text[];
+  content?: Text[];
 };
 
 type Blok = {

--- a/lib/src/utils/resolveRichTextToNodes.spec.ts
+++ b/lib/src/utils/resolveRichTextToNodes.spec.ts
@@ -195,6 +195,13 @@ describe("resolveNode", () => {
       ],
     };
 
+    const emptyNode: SchemaNode = {
+      type: "heading",
+      attrs: {
+        level: 2,
+      },
+    };
+
     // default
     expect(resolveNode(node)).toStrictEqual({
       component: "h1",
@@ -224,6 +231,11 @@ describe("resolveNode", () => {
         variant: "level-1",
       },
       content: [{ content: "Hello from rich text" }],
+    });
+
+    // empty content
+    expect(resolveNode(emptyNode)).toStrictEqual({
+      component: "br",
     });
   });
 
@@ -362,6 +374,29 @@ describe("resolveNode", () => {
       ],
     };
 
+    const nodeWithEmptyParagraph: SchemaNode = {
+      type: "list_item",
+      content: [
+        {
+          type: "paragraph",
+        },
+      ],
+    };
+
+    const nodeWithParagraphContainingHardBreaksBeforeText: SchemaNode = {
+      type: "list_item",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "hard_break" },
+            { type: "hard_break" },
+            { text: "some text", type: "text" },
+          ],
+        },
+      ],
+    };
+
     // default
     expect(resolveNode(node)).toStrictEqual({
       component: "li",
@@ -395,6 +430,32 @@ describe("resolveNode", () => {
       content: [
         {
           content: [{ content: "one" }],
+        },
+      ],
+    });
+
+    // empty content
+    expect(resolveNode(nodeWithEmptyParagraph)).toStrictEqual({
+      component: "li",
+      content: [
+        {
+          content: "",
+        },
+      ],
+    });
+
+    // hard breaks before text
+    expect(
+      resolveNode(nodeWithParagraphContainingHardBreaksBeforeText)
+    ).toStrictEqual({
+      component: "li",
+      content: [
+        {
+          content: [
+            { component: "br" },
+            { component: "br" },
+            { content: "some text" },
+          ],
         },
       ],
     });

--- a/lib/src/utils/resolveRichTextToNodes.ts
+++ b/lib/src/utils/resolveRichTextToNodes.ts
@@ -170,6 +170,13 @@ export const resolveNode = (
   if (node.type === "heading") {
     const { content, attrs } = node;
 
+    // empty line
+    if (!content) {
+      return {
+        component: "br",
+      };
+    }
+
     return {
       component: `h${attrs.level}`,
       content: content.map((node) => resolveNode(node, options)),
@@ -252,7 +259,8 @@ export const resolveNode = (
         // skip rendering p tag inside li
         if (node.type === "paragraph") {
           return {
-            content: node.content.map((node) => resolveNode(node, options)),
+            content:
+              node.content?.map((node) => resolveNode(node, options)) || "",
           };
         }
 


### PR DESCRIPTION
Hey @edvinasjurele 👋 
First of all, I want to thank you for this amazing package! The effort you put into this repo is outstanding!

I work at Storyblok in the Website team, and we were on the verge of needing to develop something like this. Since this work from yours is truly astonishing IMHO, we've been trying it out ourselves and it's working like a charm.

However, I found a couple of bugs that I've been trying to assess with this PR.

### The issue
The `Heading` content is not marked as optional, while, in fact, it is. Set aside the fact that an empty heading doesn't mean anything, there may be situations where an editor could inadvertently add a heading node to a Richtext field (which is as easy as clicking on the heading button) and then proceed to forget about it 😅 

The same thing goes for `Paragraph`s, but while handling the unhappy path is a thing in the case of plain paragraphs, it is not true for paragraphs rendered inside `List Item`s. In those cases, if a paragraph doesn't have any content, `node.content` is `undefined` and therefore an exception is thrown.

### The proposed solution
For `content`less headings: I thought it could be reasonable to render a `<br />` instead of the actual heading, much like the `paragraph` implementation, but maybe it could be better not to render anything at all?
For `p`s inside list items: it doesn't feel "right" to me to render a `<br />` in this case, as it could very well lead to quirks that may be avoided by not rendering anything 🤔
The only thing I want to point out here is that returning an empty string as content would potentially mean that empty strings could be passed as a parameter to the `renderNode` function, which is meant to only accept `ComponentNode`

I'm open to suggestions.
Thanks again for your amazing work! ❤️ 