### PR TITLE
fix types export for astro 3 and typescript 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ To get the most basic functionality, add `RichText.astro` Storyblok component to
 
 ```js
 ---
-import RichTextRenderer, { type RichTextType } from "storyblok-rich-text-astro-renderer/RichTextRenderer.astro";
+import RichTextRenderer from "storyblok-rich-text-astro-renderer/RichTextRenderer.astro";
+import type { RichTextType } from "storyblok-rich-text-astro-renderer"
 import { storyblokEditable } from "@storyblok/astro";
 
 export interface Props {

--- a/demo/src/pages/index.astro
+++ b/demo/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import type { RichTextType } from "storyblok-rich-text-astro-renderer/RichTextRenderer.astro";
+import type { RichTextType } from "storyblok-rich-text-astro-renderer";
 import Layout from "../layouts/Layout.astro";
 import StoryblokComponent from "@storyblok/astro/StoryblokComponent.astro";
 

--- a/lib/RichTextRenderer.astro
+++ b/lib/RichTextRenderer.astro
@@ -1,8 +1,6 @@
 ---
 import { resolveRichTextToNodes } from "./dist/index.mjs";
-import { ComponentNode, Options, RichTextType } from "./dist/types";
-
-export type { RichTextType };
+import type { ComponentNode, Options, RichTextType } from "./dist/types";
 
 export type Props = {
   content: RichTextType;

--- a/lib/RichTextRenderer.ts
+++ b/lib/RichTextRenderer.ts
@@ -1,0 +1,2 @@
+import RichTextRenderer from "./RichTextRenderer.astro";
+export default RichTextRenderer;

--- a/lib/package.json
+++ b/lib/package.json
@@ -22,16 +22,21 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/types/index.d.ts"
     },
-    "./RichTextRenderer.astro": "./RichTextRenderer.astro"
+    "./RichTextRenderer.astro": {
+      "import": "./RichTextRenderer.astro",
+      "types": "./RichTextRenderer.ts"
+    }
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",
   "files": [
     "dist",
-    "RichTextRenderer.astro"
+    "RichTextRenderer.astro",
+    "RichTextRenderer.ts"
   ],
   "scripts": {
     "build": "vite build",

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "module": "ESNext",
     "target": "ESNext",
-    "strict": false
+    "strict": false,
+    "jsx": "preserve"
   },
   "extends": "astro/tsconfigs/base",
   "$schema": "https://json.schemastore.org/tsconfig",


### PR DESCRIPTION
In addition to [this](https://github.com/NordSecurity/storyblok-rich-text-astro-renderer/commit/41f732dfab1df29e91f92e503409127aa132f6d9) it seems like type declarations also needs to be updated for the component to be imported without TS issues.

This PR replicates the component export process from @storyblok/astro