### PR TITLE
Fix types export after Vite v5 bump

### DIFF
--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -8,5 +8,5 @@
   "extends": "astro/tsconfigs/base",
   "$schema": "https://json.schemastore.org/tsconfig",
   "include": ["./*.astro", "./**/*.ts"],
-  "exclude": ["node_modules/*", "./vite*.ts", "dist"]
+  "exclude": ["node_modules/*", "./vite*.ts", "**/*.spec.ts", "dist"]
 }

--- a/lib/vite.config.ts
+++ b/lib/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, Plugin } from "vite";
+import { defineConfig } from "vite";
 import path from "path";
 import dts from "vite-plugin-dts";
 
@@ -13,10 +13,6 @@ export default defineConfig(() => {
         fileName: (format) => (format === "es" ? `${name}.mjs` : `${name}.js`),
       },
     },
-    plugins: [
-      dts({
-        outputDir: "dist/types",
-      }) as unknown as Plugin,
-    ],
+    plugins: [dts({ entryRoot: "src", outDir: "dist/types" })],
   };
 });


### PR DESCRIPTION
Fixes types exporting after the previous chore bumps https://github.com/NordSecurity/storyblok-rich-text-astro-renderer/pull/94/files#diff-1e946220773aef913945326261b7ee8d08b8ec29ccc66ef7c348950439212ffbR59

The main cause was that vite options changed from `build.outputDir` to `build.outDir` https://vitejs.dev/config/build-options.html#build-outdir

When looking into packages themselves:
- https://unpkg.com/browse/storyblok-rich-text-astro-renderer@2.0.0/ ✅ 
- https://unpkg.com/browse/storyblok-rich-text-astro-renderer@2.1.0/ :x: (wrong structure)
- this MR should have it fixed back to follow same structure as in 2.0.0

