### PR TITLE
[Feat] Expose the whole `Node` object to to `renderFn` instances

### DIFF
--- a/demo/src/components/Heading.astro
+++ b/demo/src/components/Heading.astro
@@ -1,0 +1,14 @@
+---
+type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+
+export type Props = {
+  as: HeadingTag;
+  text: string;
+};
+
+const { as: Element = "h1", text, ...props } = Astro.props;
+---
+
+<Element id={props.id} {...props}>
+  {text}
+</Element>

--- a/demo/src/storyblok/RichText.astro
+++ b/demo/src/storyblok/RichText.astro
@@ -12,6 +12,7 @@ import Picture from "../components/Picture.astro";
 import CodeBlock from "../components/CodeBlock.astro";
 import InlineCode from "../components/InlineCode.astro";
 import Styled from "../components/Styled.astro";
+import Heading from "../components/Heading.astro";
 
 export interface Props {
   blok: {
@@ -27,9 +28,12 @@ const { text } = blok;
   content={text}
   schema={{
     nodes: {
-      heading: ({ attrs: { level } }) => ({
-        component: Text,
-        props: { variant: `h${level}` },
+      heading: (node) => ({
+        component: Heading,
+        props: {
+          as: `h${node.attrs.level}`,
+          text: node.content?.reduce((acc, curr) => `${acc}${curr.text}`, ""),
+        },
       }),
       paragraph: () => ({
         component: Text,

--- a/demo/src/storyblok/RichText.astro
+++ b/demo/src/storyblok/RichText.astro
@@ -31,8 +31,8 @@ const { text } = blok;
       heading: (node) => ({
         component: Heading,
         props: {
-          as: `h${node.attrs.level}`,
-          text: node.content?.reduce((acc, curr) => `${acc}${curr.text}`, ""),
+          as: `h${node?.attrs.level}`,
+          text: node?.content?.reduce((acc, curr) => `${acc}${curr.text}`, ""),
         },
       }),
       paragraph: () => ({
@@ -62,30 +62,28 @@ const { text } = blok;
       blockquote: () => ({
         component: Blockquote,
       }),
-      image: ({ attrs }) => ({
+      image: (node) => ({
         component: Picture,
-        props: attrs,
+        props: node?.attrs,
       }),
-      code_block: ({ attrs }) => ({
+      code_block: (node) => ({
         component: CodeBlock,
-        props: { syntax: attrs.class?.split("-")[1] },
+        props: { syntax: node?.attrs.class?.split("-")[1] },
       }),
     },
     marks: {
-      link: ({ attrs }) => {
-        const { custom, ...restAttrs } = attrs;
-
+      link: (node) => {
         return {
           component: Link,
           props: {
-            link: { ...custom, ...restAttrs },
+            link: { ...node?.attrs },
             class: "i-am-link",
           },
         };
       },
-      styled: ({ attrs }) => ({
+      styled: (node) => ({
         component: Styled,
-        props: attrs,
+        props: node?.attrs,
       }),
       code: () => ({
         component: InlineCode,

--- a/demo/src/storyblok/RichText.astro
+++ b/demo/src/storyblok/RichText.astro
@@ -9,10 +9,11 @@ import Text from "../components/Text.astro";
 import BulletList from "../components/BulletList.astro";
 import Blockquote from "../components/Blockquote.astro";
 import Picture from "../components/Picture.astro";
-import CodeBlock from "../components/CodeBlock.astro";
+// import CodeBlock from "../components/CodeBlock.astro";
 import InlineCode from "../components/InlineCode.astro";
 import Styled from "../components/Styled.astro";
 import Heading from "../components/Heading.astro";
+import { Code } from "astro:components";
 
 export interface Props {
   blok: {
@@ -66,9 +67,21 @@ const { text } = blok;
         component: Picture,
         props: node?.attrs,
       }),
+
+      // Code example with custom code component
+      // code_block: (node) => ({
+      //   component: CodeBlock,
+      //   props: { syntax: node?.attrs.class?.split("-")[1] },
+      // }),
+
+      // Code example with native Astro Code component
       code_block: (node) => ({
-        component: CodeBlock,
-        props: { syntax: node?.attrs.class?.split("-")[1] },
+        component: Code,
+        props: {
+          lang: node?.attrs.class?.split("-")[1],
+          theme: "solarized-dark",
+          code: node?.content?.reduce((acc, curr) => `${acc}${curr.text}`, ""),
+        },
       }),
     },
     marks: {

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -8,7 +8,7 @@ export type ComponentNode = {
   content?: string | ComponentNode[];
 };
 
-type Resolver<Node = null> = (node: Node) => ComponentNode;
+export type Resolver<Node = null> = (node?: Node) => ComponentNode;
 
 export type Schema = {
   nodes?: {

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -8,7 +8,7 @@ export type ComponentNode = {
   content?: string | ComponentNode[];
 };
 
-export type Resolver<Node = null> = (node?: Node) => ComponentNode;
+export type Resolver<Node = unknown> = (node?: Node) => ComponentNode;
 
 export type Schema = {
   nodes?: {

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -8,37 +8,36 @@ export type ComponentNode = {
   content?: string | ComponentNode[];
 };
 
-type ResolverAttrs<Attrs> = ({ attrs }: { attrs: Attrs }) => ComponentNode;
-type Resolver = () => ComponentNode;
+type Resolver<Node = null> = (node: Node) => ComponentNode;
 
 export type Schema = {
   nodes?: {
-    heading?: ResolverAttrs<Heading["attrs"]>;
-    paragraph?: Resolver;
-    text?: Resolver;
-    hard_break?: Resolver;
-    bullet_list?: Resolver;
-    ordered_list?: ResolverAttrs<OrderedList["attrs"]>;
-    list_item?: Resolver;
-    horizontal_rule?: Resolver;
-    blockquote?: Resolver;
-    image?: ResolverAttrs<Image["attrs"]>;
-    code_block?: ResolverAttrs<CodeBlock["attrs"]>;
-    emoji?: ResolverAttrs<Emoji["attrs"]>;
+    heading?: Resolver<Heading>;
+    paragraph?: Resolver<Paragraph>;
+    text?: Resolver<Text>;
+    hard_break?: Resolver<Break>;
+    bullet_list?: Resolver<BulletList>;
+    ordered_list?: Resolver<OrderedList>;
+    list_item?: Resolver<ListItem>;
+    horizontal_rule?: Resolver<HorizontalRule>;
+    blockquote?: Resolver<Blockquote>;
+    image?: Resolver<Image>;
+    code_block?: Resolver<CodeBlock>;
+    emoji?: Resolver<Emoji>;
   };
   marks?: {
-    link?: ResolverAttrs<Link["attrs"]>;
+    link?: Resolver<Link>;
     bold?: Resolver;
     underline?: Resolver;
     italic?: Resolver;
-    styled?: ResolverAttrs<Styled["attrs"]>;
+    styled?: Resolver<Styled>;
     strike?: Resolver;
     superscript?: Resolver;
     subscript?: Resolver;
     code?: Resolver;
-    anchor?: ResolverAttrs<Anchor["attrs"]>;
-    textStyle?: ResolverAttrs<TextStyle["attrs"]>;
-    highlight?: ResolverAttrs<Highlight["attrs"]>;
+    anchor?: Resolver<Anchor>;
+    textStyle?: Resolver<TextStyle>;
+    highlight?: Resolver<Highlight>;
   };
 };
 

--- a/lib/src/utils/resolveRichTextToNodes.ts
+++ b/lib/src/utils/resolveRichTextToNodes.ts
@@ -2,6 +2,7 @@ import type {
   ComponentNode,
   Mark,
   Options,
+  Resolver,
   RichTextType,
   Schema,
   SchemaNode,
@@ -14,7 +15,7 @@ export const resolveMark = (
   schema?: Schema
 ): ComponentNode => {
   if (mark.type === "link") {
-    const resolverFn = schema?.marks?.[mark.type];
+    const resolverFn: Resolver<unknown> = schema?.marks?.[mark.type];
 
     const attrs = { ...mark.attrs };
     const { linktype = "url" } = mark.attrs;
@@ -39,7 +40,7 @@ export const resolveMark = (
       component: "a",
       props: attrs,
       content,
-      ...resolverFn?.({ attrs: mark.attrs }),
+      ...resolverFn?.(mark),
     };
   }
 
@@ -78,7 +79,7 @@ export const resolveMark = (
       component: "span",
       props: attrs,
       content,
-      ...resolverFn?.({ attrs }),
+      ...resolverFn?.(mark),
     };
   }
 
@@ -126,7 +127,7 @@ export const resolveMark = (
       component: "span",
       content,
       props: attrs,
-      ...resolverFn?.({ attrs }),
+      ...resolverFn?.(mark),
     };
   }
 
@@ -140,7 +141,7 @@ export const resolveMark = (
       props: {
         style: { color: attrs.color },
       },
-      ...resolverFn?.({ attrs }),
+      ...resolverFn?.(mark),
     };
   }
 
@@ -154,7 +155,7 @@ export const resolveMark = (
       props: {
         style: { backgroundColor: attrs.color },
       },
-      ...resolverFn?.({ attrs }),
+      ...resolverFn?.(mark),
     };
   }
 };
@@ -165,9 +166,9 @@ export const resolveNode = (
   options: Options = {}
 ): ComponentNode => {
   const { schema } = options;
-  const resolverFn = schema?.nodes?.[node.type];
 
   if (node.type === "heading") {
+    const resolverFn = schema?.nodes?.[node.type];
     const { content, attrs } = node;
 
     // empty line
@@ -180,77 +181,87 @@ export const resolveNode = (
     return {
       component: `h${attrs.level}`,
       content: content.map((node) => resolveNode(node, options)),
-      ...resolverFn?.({ attrs }),
+      ...resolverFn?.(node),
     };
   }
 
   if (node.type === "hard_break") {
+    const resolverFn = schema?.nodes?.[node.type];
+
     return {
       component: "br",
-      ...resolverFn?.(),
+      ...resolverFn?.(node),
     };
   }
 
   if (node.type === "horizontal_rule") {
+    const resolverFn = schema?.nodes?.[node.type];
+
     return {
       component: "hr",
-      ...resolverFn?.(),
+      ...resolverFn?.(node),
     };
   }
 
   if (node.type === "blockquote") {
+    const resolverFn = schema?.nodes?.[node.type];
     const { content } = node;
 
     return {
       component: "blockquote",
       content: content.map((node) => resolveNode(node, options)),
-      ...resolverFn?.(),
+      ...resolverFn?.(node),
     };
   }
 
   if (node.type === "image") {
+    const resolverFn = schema?.nodes?.[node.type];
     const { attrs } = node;
     const { src, alt } = attrs;
 
     return {
       component: "img",
       props: { src, alt },
-      ...resolverFn?.({ attrs }),
+      ...resolverFn?.(node),
     };
   }
 
   if (node.type === "code_block") {
+    const resolverFn = schema?.nodes?.[node.type];
     const { attrs, content } = node;
 
     return {
       component: "pre",
       props: { class: attrs.class },
       content: content.map((node) => resolveNode(node, options)),
-      ...resolverFn?.({ attrs }),
+      ...resolverFn?.(node),
     };
   }
 
   if (node.type === "ordered_list") {
-    const { content, attrs } = node;
+    const resolverFn = schema?.nodes?.[node.type];
+    const { content } = node;
 
     return {
       component: "ol",
       content: content.map((node) => resolveNode(node, options)),
-      ...resolverFn?.({ attrs }),
+      ...resolverFn?.(node),
     };
   }
 
   if (node.type === "bullet_list") {
+    const resolverFn = schema?.nodes?.[node.type];
     const { content } = node;
 
     return {
       component: "ul",
       content: content.map((node) => resolveNode(node, options)),
-      ...resolverFn?.(),
+      ...resolverFn?.(node),
     };
   }
 
   if (node.type === "list_item") {
+    const resolverFn = schema?.nodes?.[node.type];
     const { content } = node;
 
     return {
@@ -266,11 +277,12 @@ export const resolveNode = (
 
         return resolveNode(node, options);
       }),
-      ...resolverFn?.(),
+      ...resolverFn?.(node),
     };
   }
 
   if (node.type === "text") {
+    const resolverFn = schema?.nodes?.[node.type];
     const { text, marks } = node;
 
     if (marks) {
@@ -281,17 +293,18 @@ export const resolveNode = (
 
       return {
         content: marked,
-        ...resolverFn?.(),
+        ...resolverFn?.(node),
       };
     }
 
     return {
       content: text,
-      ...resolverFn?.(),
+      ...resolverFn?.(node),
     };
   }
 
   if (node.type === "paragraph") {
+    const resolverFn = schema?.nodes?.[node.type];
     const { content } = node;
 
     // empty line
@@ -304,7 +317,7 @@ export const resolveNode = (
     return {
       component: "p",
       content: content.map((node) => resolveNode(node, options)),
-      ...resolverFn?.(),
+      ...resolverFn?.(node),
     };
   }
 
@@ -322,12 +335,13 @@ export const resolveNode = (
   }
 
   if (node.type === "emoji") {
+    const resolverFn = schema?.nodes?.[node.type];
     const { attrs } = node;
     const { emoji } = attrs;
 
     return {
       content: emoji,
-      ...resolverFn?.({ attrs }),
+      ...resolverFn?.(node),
     };
   }
 };


### PR DESCRIPTION
The purpose of this PR is to provide an initial solution to the issue reported on #129 
If we let users get the whole `Node` object inside schema resolver functions, they will be able to use that data (map pieces of content to specific props, use as conditional logic, etc.).