### PR TITLE
chore: extended props for renderer

### DIFF
--- a/lib/RichTextRenderer.astro
+++ b/lib/RichTextRenderer.astro
@@ -1,8 +1,9 @@
 ---
+import type { HTMLAttributes } from "astro/types";
 import { resolveRichTextToNodes } from "./dist/index.mjs";
 import type { ComponentNode, Options, RichTextType } from "./dist/types";
 
-export type Props = {
+export type Props = HTMLAttributes<"div"> & {
   content: RichTextType;
   schema?: Options["schema"];
   /**


### PR DESCRIPTION
since we pass the rest of props to div element, we probably want to pass some props like 'class', 'style' and others to the parent element. it works now though type system will definitely complain about that