### PR TITLE
fix: make attrs.color optional chain

### DIFF
--- a/lib/src/utils/resolveRichTextToNodes.ts
+++ b/lib/src/utils/resolveRichTextToNodes.ts
@@ -139,7 +139,7 @@ export const resolveMark = (
       component: "span",
       content,
       props: {
-        style: { color: attrs.color },
+        style: { color: attrs?.color },
       },
       ...resolverFn?.(mark),
     };
@@ -153,7 +153,7 @@ export const resolveMark = (
       component: "span",
       content,
       props: {
-        style: { backgroundColor: attrs.color },
+        style: { backgroundColor: attrs?.color },
       },
       ...resolverFn?.(mark),
     };


### PR DESCRIPTION
I ran into an issue where storyblok, for some reason or another, didn't set the attrs object on a `textStyle` markup fragment. Just ~~one~~ three of them though, out of about 180 on my Page blok.

This attribute object being missing shouldn't make my build fail (the prop is usually set to `""` or `null` anyways), so ideally this should fix it.

### The error I had before this fix:
![image](https://github.com/user-attachments/assets/59572ec6-6126-452f-8744-963f6374a93e)
