### PR TITLE
chore: bump astro 5.11 and storyblok/astro 7.2

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -12,8 +12,8 @@
     "try": "npm run build & npm run preview"
   },
   "dependencies": {
-    "@storyblok/astro": "^6.2.0",
-    "astro": "^5.7.14"
+    "@storyblok/astro": "^7.2.0",
+    "astro": "^5.11.0"
   },
   "stackblitz": {
     "startCommand": "npm run start-stackblitz"

--- a/lib/package.json
+++ b/lib/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@storyblok/js": "^4.2.0",
-    "astro": "^5.7.14",
+    "astro": "^5.11.0",
     "vite": "^6.3.5",
     "vite-plugin-dts": "^4.5.4"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
     "demo": {
       "version": "0.0.0",
       "dependencies": {
-        "@storyblok/astro": "^6.2.0",
-        "astro": "^5.7.14"
+        "@storyblok/astro": "^7.2.0",
+        "astro": "^5.11.0"
       }
     },
     "lib": {
@@ -41,7 +41,7 @@
       "license": "MIT",
       "devDependencies": {
         "@storyblok/js": "^4.2.0",
-        "astro": "^5.7.14",
+        "astro": "^5.11.0",
         "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.4"
       },
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.0.tgz",
-      "integrity": "sha512-7bCjW6tVDpUurQLeKBUN9tZ5kSv5qYrGmcn0sG0IwacL7isR2ZbyyA3AdZ4uxsuUFOS2SlgReTH7wkxO6zpqWA==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.2.tgz",
+      "integrity": "sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw==",
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
@@ -71,13 +71,13 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.1.tgz",
-      "integrity": "sha512-c5F5gGrkczUaTVgmMW9g1YMJGzOtRvjjhw6IfGuxarM6ct09MpwysP10US729dy07gg8y+ofVifezvP3BNsWZg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.2.tgz",
+      "integrity": "sha512-bO35JbWpVvyKRl7cmSJD822e8YA8ThR/YbUsciWNA7yTcqpIAL2hJDToWP5KcZBWxGT6IOdOkHSXARSNZc4l/Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/internal-helpers": "0.6.1",
-        "@astrojs/prism": "3.2.0",
+        "@astrojs/prism": "3.3.0",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
@@ -88,9 +88,9 @@
         "rehype-stringify": "^10.0.1",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.1",
+        "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "shiki": "^3.0.0",
+        "shiki": "^3.2.1",
         "smol-toml": "^1.3.1",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
@@ -100,21 +100,21 @@
       }
     },
     "node_modules/@astrojs/prism": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.2.0.tgz",
-      "integrity": "sha512-GilTHKGCW6HMq7y3BUv9Ac7GMe/MO9gi9GW62GzKtth0SwukCu/qp2wLiGpEujhY+VVhaG9v7kv/5vFzvf4NYw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+      "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
       "license": "MIT",
       "dependencies": {
-        "prismjs": "^1.29.0"
+        "prismjs": "^1.30.0"
       },
       "engines": {
-        "node": "^18.17.1 || ^20.3.0 || >=22.0.0"
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.2.1.tgz",
-      "integrity": "sha512-SSVM820Jqc6wjsn7qYfV9qfeQvePtVc1nSofhyap7l0/iakUKywj3hfy3UJAOV4sGV4Q/u450RD4AaCaFvNPlg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
       "license": "MIT",
       "dependencies": {
         "ci-info": "^4.2.0",
@@ -126,7 +126,7 @@
         "which-pm-runs": "^1.1.0"
       },
       "engines": {
-        "node": "^18.17.1 || ^20.3.0 || >=22.0.0"
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
     "node_modules/@astrojs/telemetry/node_modules/debug": {
@@ -1678,60 +1678,60 @@
       }
     },
     "node_modules/@shikijs/core": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.4.2.tgz",
-      "integrity": "sha512-AG8vnSi1W2pbgR2B911EfGqtLE9c4hQBYkv/x7Z+Kt0VxhgQKcW7UNDVYsu9YxwV6u+OJrvdJrMq6DNWoBjihQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.7.0.tgz",
+      "integrity": "sha512-yilc0S9HvTPyahHpcum8eonYrQtmGTU0lbtwxhA6jHv4Bm1cAdlPFRCJX4AHebkCm75aKTjjRAW+DezqD1b/cg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.4.2.tgz",
-      "integrity": "sha512-1/adJbSMBOkpScCE/SB6XkjJU17ANln3Wky7lOmrnpl+zBdQ1qXUJg2GXTYVHRq+2j3hd1DesmElTXYDgtfSOQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.7.0.tgz",
+      "integrity": "sha512-0t17s03Cbv+ZcUvv+y33GtX75WBLQELgNdVghnsdhTgU3hVcWcMsoP6Lb0nDTl95ZJfbP1mVMO0p3byVh3uuzA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.3"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.2.tgz",
-      "integrity": "sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.7.0.tgz",
+      "integrity": "sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.2.tgz",
-      "integrity": "sha512-H6azIAM+OXD98yztIfs/KH5H4PU39t+SREhmM8LaNXyUrqj2mx+zVkr8MWYqjceSjDw9I1jawm1WdFqU806rMA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.7.0.tgz",
+      "integrity": "sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2"
+        "@shikijs/types": "3.7.0"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.2.tgz",
-      "integrity": "sha512-qAEuAQh+brd8Jyej2UDDf+b4V2g1Rm8aBIdvt32XhDPrHvDkEnpb7Kzc9hSuHUxz0Iuflmq7elaDuQAP9bHIhg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.7.0.tgz",
+      "integrity": "sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.4.2"
+        "@shikijs/types": "3.7.0"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.2.tgz",
-      "integrity": "sha512-zHC1l7L+eQlDXLnxvM9R91Efh2V4+rN3oMVS2swCBssbj2U/FBwybD1eeLaq8yl/iwT+zih8iUbTBCgGZOYlVg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.7.0.tgz",
+      "integrity": "sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -1745,39 +1745,22 @@
       "license": "MIT"
     },
     "node_modules/@storyblok/astro": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@storyblok/astro/-/astro-6.2.0.tgz",
-      "integrity": "sha512-EsUwDXykEDCPeTgCrLPsHT/ZOif08m2YDFK8eJ47WNytxoW2fPcuMEksB77LAnUmlSLHAWap4zOtm5TMFsBKNg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@storyblok/astro/-/astro-7.2.0.tgz",
+      "integrity": "sha512-zyzY4f2JBWU+ueSvTOaijd3j4dKurPd1ExJlcrhX3aY3uzooBi5XqF9j1Z6eG7Wpqlb1PXCKRy/M7txyI8XUuQ==",
       "license": "MIT",
       "dependencies": {
-        "@storyblok/js": "3.5.0",
+        "@storyblok/js": "4.2.0",
         "camelcase": "^8.0.0"
       },
       "peerDependencies": {
         "astro": "^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
-    "node_modules/@storyblok/astro/node_modules/@storyblok/js": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-3.5.0.tgz",
-      "integrity": "sha512-1gGY6t4CIZNOt9t5h+Q7lMN6lfG8VgrChktv1L3gsMzBcOcEnQdr7ZeqUWFbB9VlGPc8X/RRfULRgckzEwJ6BA==",
-      "license": "MIT",
-      "dependencies": {
-        "@storyblok/richtext": "3.2.0",
-        "storyblok-js-client": "6.11.0"
-      }
-    },
-    "node_modules/@storyblok/astro/node_modules/storyblok-js-client": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.11.0.tgz",
-      "integrity": "sha512-2uhd/VA51AB88XoqQ+rw9JqkWNoPl2ydg+J49w+2KBqqFvV2EtUhrS2umnabU8sD7HftFsMg0n69EWhkeDyM/A==",
-      "license": "MIT"
-    },
     "node_modules/@storyblok/js": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-4.2.0.tgz",
       "integrity": "sha512-mZcnpwn36ZWf60Jrn1ArLYvDNfPa2EeKsmrF59za8rk1/CDnzBusvnGB+blPIe1xPBjVd8np3MxkY/KKP++QJQ==",
-      "dev": true,
       "dependencies": {
         "@storyblok/richtext": "3.5.0",
         "storyblok-js-client": "7.1.0"
@@ -1786,14 +1769,7 @@
     "node_modules/@storyblok/js/node_modules/@storyblok/richtext": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@storyblok/richtext/-/richtext-3.5.0.tgz",
-      "integrity": "sha512-uHYmoC0ytQHDPs02JYHE98Lt3cwokPkCtOvE68ArJNtDvh9O+3UlSyytKZy+uhnrhajvF4BJzkbHwo6wOuunog==",
-      "dev": true
-    },
-    "node_modules/@storyblok/richtext": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@storyblok/richtext/-/richtext-3.2.0.tgz",
-      "integrity": "sha512-koVGDv1HtiI5vymE5fzRB1VO1PNguj+RSfHI4zCy2+90pRoqZbsUCR8V2TaNl7Pg8R1oOkFZnbAxdt9Z4xoxDg==",
-      "license": "MIT"
+      "integrity": "sha512-uHYmoC0ytQHDPs02JYHE98Lt3cwokPkCtOvE68ArJNtDvh9O+3UlSyytKZy+uhnrhajvF4BJzkbHwo6wOuunog=="
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
@@ -2768,15 +2744,15 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.7.14",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.7.14.tgz",
-      "integrity": "sha512-DfuDD49f7mbHB7ygLm8KXEC6QQtpLoNrmoylcMLKdl1ahXNdiw+mgW8ApEMyHTUyVrqEUnr4gZCKSlZ9POCHjQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.11.0.tgz",
+      "integrity": "sha512-MEICntERthUxJPSSDsDiZuwiCMrsaYy3fnDhp4c6ScUfldCB8RBnB/myYdpTFXpwYBy6SgVsHQ1H4MuuA7ro/Q==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^2.11.0",
+        "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.6.1",
-        "@astrojs/markdown-remark": "6.3.1",
-        "@astrojs/telemetry": "3.2.1",
+        "@astrojs/markdown-remark": "6.3.2",
+        "@astrojs/telemetry": "3.3.0",
         "@capsizecss/unpack": "^2.4.0",
         "@oslojs/encoding": "^1.1.0",
         "@rollup/pluginutils": "^5.1.4",
@@ -2839,7 +2815,7 @@
         "astro": "astro.js"
       },
       "engines": {
-        "node": "^18.17.1 || ^20.3.0 || >=22.0.0",
+        "node": "18.20.8 || ^20.3.0 || >=22.0.0",
         "npm": ">=9.6.5",
         "pnpm": ">=7.1.0"
       },
@@ -3613,9 +3589,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
       "funding": [
         {
           "type": "github",
@@ -4083,9 +4059,9 @@
       }
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
-      "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -8113,17 +8089,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.4.2.tgz",
-      "integrity": "sha512-wuxzZzQG8kvZndD7nustrNFIKYJ1jJoWIPaBpVe2+KHSvtzMi4SBjOxrigs8qeqce/l3U0cwiC+VAkLKSunHQQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.7.0.tgz",
+      "integrity": "sha512-ZcI4UT9n6N2pDuM2n3Jbk0sR4Swzq43nLPgS/4h0E3B/NrFn2HKElrDtceSf8Zx/OWYOo7G1SAtBLypCp+YXqg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.4.2",
-        "@shikijs/engine-javascript": "3.4.2",
-        "@shikijs/engine-oniguruma": "3.4.2",
-        "@shikijs/langs": "3.4.2",
-        "@shikijs/themes": "3.4.2",
-        "@shikijs/types": "3.4.2",
+        "@shikijs/core": "3.7.0",
+        "@shikijs/engine-javascript": "3.7.0",
+        "@shikijs/engine-oniguruma": "3.7.0",
+        "@shikijs/langs": "3.7.0",
+        "@shikijs/themes": "3.7.0",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
@@ -8208,9 +8184,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.4.tgz",
-      "integrity": "sha512-UOPtVuYkzYGee0Bd2Szz8d2G3RfMfJ2t3qVdZUAozZyAk+a0Sxa+QKix0YCwjL/A1RR0ar44nCxaoN9FxdJGwA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.1.tgz",
+      "integrity": "sha512-CxdwHXyYTONGHThDbq5XdwbFsuY4wlClRGejfE2NtwUtiHYsP1QtNsHb/hnj31jKYSchztJsaA8pSQoVzkfCFg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -8318,8 +8294,7 @@
     "node_modules/storyblok-js-client": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-7.1.0.tgz",
-      "integrity": "sha512-nOCzlVbAsfUDJJBNWiiqDo1q+tUldHoMh6Lqgger/KLaq2m+2haw9S/ad+Ru8/UU5izxzSLwc083cycdNk9Gdg==",
-      "dev": true
+      "integrity": "sha512-nOCzlVbAsfUDJJBNWiiqDo1q+tUldHoMh6Lqgger/KLaq2m+2haw9S/ad+Ru8/UU5izxzSLwc083cycdNk9Gdg=="
     },
     "node_modules/storyblok-rich-text-astro-renderer": {
       "resolved": "lib",
@@ -10086,9 +10061,9 @@
       "dev": true
     },
     "@astrojs/compiler": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.0.tgz",
-      "integrity": "sha512-7bCjW6tVDpUurQLeKBUN9tZ5kSv5qYrGmcn0sG0IwacL7isR2ZbyyA3AdZ4uxsuUFOS2SlgReTH7wkxO6zpqWA=="
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.2.tgz",
+      "integrity": "sha512-w2zfvhjNCkNMmMMOn5b0J8+OmUaBL1o40ipMvqcG6NRpdC+lKxmTi48DT8Xw0SzJ3AfmeFLB45zXZXtmbsjcgw=="
     },
     "@astrojs/internal-helpers": {
       "version": "0.6.1",
@@ -10096,12 +10071,12 @@
       "integrity": "sha512-l5Pqf6uZu31aG+3Lv8nl/3s4DbUzdlxTWDof4pEpto6GUJNhhCbelVi9dEyurOVyqaelwmS9oSyOWOENSfgo9A=="
     },
     "@astrojs/markdown-remark": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.1.tgz",
-      "integrity": "sha512-c5F5gGrkczUaTVgmMW9g1YMJGzOtRvjjhw6IfGuxarM6ct09MpwysP10US729dy07gg8y+ofVifezvP3BNsWZg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.2.tgz",
+      "integrity": "sha512-bO35JbWpVvyKRl7cmSJD822e8YA8ThR/YbUsciWNA7yTcqpIAL2hJDToWP5KcZBWxGT6IOdOkHSXARSNZc4l/Q==",
       "requires": {
         "@astrojs/internal-helpers": "0.6.1",
-        "@astrojs/prism": "3.2.0",
+        "@astrojs/prism": "3.3.0",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
@@ -10112,9 +10087,9 @@
         "rehype-stringify": "^10.0.1",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
-        "remark-rehype": "^11.1.1",
+        "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
-        "shiki": "^3.0.0",
+        "shiki": "^3.2.1",
         "smol-toml": "^1.3.1",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
@@ -10124,17 +10099,17 @@
       }
     },
     "@astrojs/prism": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.2.0.tgz",
-      "integrity": "sha512-GilTHKGCW6HMq7y3BUv9Ac7GMe/MO9gi9GW62GzKtth0SwukCu/qp2wLiGpEujhY+VVhaG9v7kv/5vFzvf4NYw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-3.3.0.tgz",
+      "integrity": "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==",
       "requires": {
-        "prismjs": "^1.29.0"
+        "prismjs": "^1.30.0"
       }
     },
     "@astrojs/telemetry": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.2.1.tgz",
-      "integrity": "sha512-SSVM820Jqc6wjsn7qYfV9qfeQvePtVc1nSofhyap7l0/iakUKywj3hfy3UJAOV4sGV4Q/u450RD4AaCaFvNPlg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
+      "integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
       "requires": {
         "ci-info": "^4.2.0",
         "debug": "^4.4.0",
@@ -11072,55 +11047,55 @@
       }
     },
     "@shikijs/core": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.4.2.tgz",
-      "integrity": "sha512-AG8vnSi1W2pbgR2B911EfGqtLE9c4hQBYkv/x7Z+Kt0VxhgQKcW7UNDVYsu9YxwV6u+OJrvdJrMq6DNWoBjihQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.7.0.tgz",
+      "integrity": "sha512-yilc0S9HvTPyahHpcum8eonYrQtmGTU0lbtwxhA6jHv4Bm1cAdlPFRCJX4AHebkCm75aKTjjRAW+DezqD1b/cg==",
       "requires": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
       }
     },
     "@shikijs/engine-javascript": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.4.2.tgz",
-      "integrity": "sha512-1/adJbSMBOkpScCE/SB6XkjJU17ANln3Wky7lOmrnpl+zBdQ1qXUJg2GXTYVHRq+2j3hd1DesmElTXYDgtfSOQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.7.0.tgz",
+      "integrity": "sha512-0t17s03Cbv+ZcUvv+y33GtX75WBLQELgNdVghnsdhTgU3hVcWcMsoP6Lb0nDTl95ZJfbP1mVMO0p3byVh3uuzA==",
       "requires": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.3"
       }
     },
     "@shikijs/engine-oniguruma": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.2.tgz",
-      "integrity": "sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.7.0.tgz",
+      "integrity": "sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==",
       "requires": {
-        "@shikijs/types": "3.4.2",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "@shikijs/langs": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.2.tgz",
-      "integrity": "sha512-H6azIAM+OXD98yztIfs/KH5H4PU39t+SREhmM8LaNXyUrqj2mx+zVkr8MWYqjceSjDw9I1jawm1WdFqU806rMA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.7.0.tgz",
+      "integrity": "sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==",
       "requires": {
-        "@shikijs/types": "3.4.2"
+        "@shikijs/types": "3.7.0"
       }
     },
     "@shikijs/themes": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.2.tgz",
-      "integrity": "sha512-qAEuAQh+brd8Jyej2UDDf+b4V2g1Rm8aBIdvt32XhDPrHvDkEnpb7Kzc9hSuHUxz0Iuflmq7elaDuQAP9bHIhg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.7.0.tgz",
+      "integrity": "sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==",
       "requires": {
-        "@shikijs/types": "3.4.2"
+        "@shikijs/types": "3.7.0"
       }
     },
     "@shikijs/types": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.2.tgz",
-      "integrity": "sha512-zHC1l7L+eQlDXLnxvM9R91Efh2V4+rN3oMVS2swCBssbj2U/FBwybD1eeLaq8yl/iwT+zih8iUbTBCgGZOYlVg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.7.0.tgz",
+      "integrity": "sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==",
       "requires": {
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
@@ -11132,35 +11107,18 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="
     },
     "@storyblok/astro": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@storyblok/astro/-/astro-6.2.0.tgz",
-      "integrity": "sha512-EsUwDXykEDCPeTgCrLPsHT/ZOif08m2YDFK8eJ47WNytxoW2fPcuMEksB77LAnUmlSLHAWap4zOtm5TMFsBKNg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@storyblok/astro/-/astro-7.2.0.tgz",
+      "integrity": "sha512-zyzY4f2JBWU+ueSvTOaijd3j4dKurPd1ExJlcrhX3aY3uzooBi5XqF9j1Z6eG7Wpqlb1PXCKRy/M7txyI8XUuQ==",
       "requires": {
-        "@storyblok/js": "3.5.0",
+        "@storyblok/js": "4.2.0",
         "camelcase": "^8.0.0"
-      },
-      "dependencies": {
-        "@storyblok/js": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-3.5.0.tgz",
-          "integrity": "sha512-1gGY6t4CIZNOt9t5h+Q7lMN6lfG8VgrChktv1L3gsMzBcOcEnQdr7ZeqUWFbB9VlGPc8X/RRfULRgckzEwJ6BA==",
-          "requires": {
-            "@storyblok/richtext": "3.2.0",
-            "storyblok-js-client": "6.11.0"
-          }
-        },
-        "storyblok-js-client": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.11.0.tgz",
-          "integrity": "sha512-2uhd/VA51AB88XoqQ+rw9JqkWNoPl2ydg+J49w+2KBqqFvV2EtUhrS2umnabU8sD7HftFsMg0n69EWhkeDyM/A=="
-        }
       }
     },
     "@storyblok/js": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@storyblok/js/-/js-4.2.0.tgz",
       "integrity": "sha512-mZcnpwn36ZWf60Jrn1ArLYvDNfPa2EeKsmrF59za8rk1/CDnzBusvnGB+blPIe1xPBjVd8np3MxkY/KKP++QJQ==",
-      "dev": true,
       "requires": {
         "@storyblok/richtext": "3.5.0",
         "storyblok-js-client": "7.1.0"
@@ -11169,15 +11127,9 @@
         "@storyblok/richtext": {
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/@storyblok/richtext/-/richtext-3.5.0.tgz",
-          "integrity": "sha512-uHYmoC0ytQHDPs02JYHE98Lt3cwokPkCtOvE68ArJNtDvh9O+3UlSyytKZy+uhnrhajvF4BJzkbHwo6wOuunog==",
-          "dev": true
+          "integrity": "sha512-uHYmoC0ytQHDPs02JYHE98Lt3cwokPkCtOvE68ArJNtDvh9O+3UlSyytKZy+uhnrhajvF4BJzkbHwo6wOuunog=="
         }
       }
-    },
-    "@storyblok/richtext": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@storyblok/richtext/-/richtext-3.2.0.tgz",
-      "integrity": "sha512-koVGDv1HtiI5vymE5fzRB1VO1PNguj+RSfHI4zCy2+90pRoqZbsUCR8V2TaNl7Pg8R1oOkFZnbAxdt9Z4xoxDg=="
     },
     "@swc/helpers": {
       "version": "0.5.17",
@@ -11861,14 +11813,14 @@
       "dev": true
     },
     "astro": {
-      "version": "5.7.14",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.7.14.tgz",
-      "integrity": "sha512-DfuDD49f7mbHB7ygLm8KXEC6QQtpLoNrmoylcMLKdl1ahXNdiw+mgW8ApEMyHTUyVrqEUnr4gZCKSlZ9POCHjQ==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.11.0.tgz",
+      "integrity": "sha512-MEICntERthUxJPSSDsDiZuwiCMrsaYy3fnDhp4c6ScUfldCB8RBnB/myYdpTFXpwYBy6SgVsHQ1H4MuuA7ro/Q==",
       "requires": {
-        "@astrojs/compiler": "^2.11.0",
+        "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.6.1",
-        "@astrojs/markdown-remark": "6.3.1",
-        "@astrojs/telemetry": "3.2.1",
+        "@astrojs/markdown-remark": "6.3.2",
+        "@astrojs/telemetry": "3.3.0",
         "@capsizecss/unpack": "^2.4.0",
         "@oslojs/encoding": "^1.1.0",
         "@rollup/pluginutils": "^5.1.4",
@@ -12308,9 +12260,9 @@
       }
     },
     "ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ=="
     },
     "cli-boxes": {
       "version": "3.0.0",
@@ -12636,9 +12588,9 @@
       }
     },
     "decode-named-character-reference": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
-      "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
       "requires": {
         "character-entities": "^2.0.0"
       }
@@ -12669,8 +12621,8 @@
     "demo": {
       "version": "file:demo",
       "requires": {
-        "@storyblok/astro": "^6.2.0",
-        "astro": "^5.7.14"
+        "@storyblok/astro": "^7.2.0",
+        "astro": "^5.11.0"
       }
     },
     "dequal": {
@@ -15347,16 +15299,16 @@
       "dev": true
     },
     "shiki": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.4.2.tgz",
-      "integrity": "sha512-wuxzZzQG8kvZndD7nustrNFIKYJ1jJoWIPaBpVe2+KHSvtzMi4SBjOxrigs8qeqce/l3U0cwiC+VAkLKSunHQQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.7.0.tgz",
+      "integrity": "sha512-ZcI4UT9n6N2pDuM2n3Jbk0sR4Swzq43nLPgS/4h0E3B/NrFn2HKElrDtceSf8Zx/OWYOo7G1SAtBLypCp+YXqg==",
       "requires": {
-        "@shikijs/core": "3.4.2",
-        "@shikijs/engine-javascript": "3.4.2",
-        "@shikijs/engine-oniguruma": "3.4.2",
-        "@shikijs/langs": "3.4.2",
-        "@shikijs/themes": "3.4.2",
-        "@shikijs/types": "3.4.2",
+        "@shikijs/core": "3.7.0",
+        "@shikijs/engine-javascript": "3.7.0",
+        "@shikijs/engine-oniguruma": "3.7.0",
+        "@shikijs/langs": "3.7.0",
+        "@shikijs/themes": "3.7.0",
+        "@shikijs/types": "3.7.0",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
@@ -15420,9 +15372,9 @@
       }
     },
     "smol-toml": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.4.tgz",
-      "integrity": "sha512-UOPtVuYkzYGee0Bd2Szz8d2G3RfMfJ2t3qVdZUAozZyAk+a0Sxa+QKix0YCwjL/A1RR0ar44nCxaoN9FxdJGwA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.1.tgz",
+      "integrity": "sha512-CxdwHXyYTONGHThDbq5XdwbFsuY4wlClRGejfE2NtwUtiHYsP1QtNsHb/hnj31jKYSchztJsaA8pSQoVzkfCFg=="
     },
     "sort-object-keys": {
       "version": "1.1.3",
@@ -15496,14 +15448,13 @@
     "storyblok-js-client": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-7.1.0.tgz",
-      "integrity": "sha512-nOCzlVbAsfUDJJBNWiiqDo1q+tUldHoMh6Lqgger/KLaq2m+2haw9S/ad+Ru8/UU5izxzSLwc083cycdNk9Gdg==",
-      "dev": true
+      "integrity": "sha512-nOCzlVbAsfUDJJBNWiiqDo1q+tUldHoMh6Lqgger/KLaq2m+2haw9S/ad+Ru8/UU5izxzSLwc083cycdNk9Gdg=="
     },
     "storyblok-rich-text-astro-renderer": {
       "version": "file:lib",
       "requires": {
         "@storyblok/js": "^4.2.0",
-        "astro": "^5.7.14",
+        "astro": "^5.11.0",
         "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.4"
       }


### PR DESCRIPTION
Changes:
 - Bump `@storyblok/astro` to 7.2.0
 - Bump `astro` to 5.11.0